### PR TITLE
Init param array list in hevc_construct_specific_parameters

### DIFF
--- a/codecs/hevc.c
+++ b/codecs/hevc.c
@@ -2988,6 +2988,7 @@ int hevc_construct_specific_parameters
         temp8 = lsmash_bs_get_byte( bs );
         param_array.array_completeness = (temp8 >> 7) & 0x01;
         param_array.NAL_unit_type      =  temp8       & 0x3F;
+        lsmash_list_init(param_array.list, isom_remove_dcr_ps);
         param_array.list->entry_count  = lsmash_bs_get_be16( bs );
         if( param_array.NAL_unit_type == HEVC_NALU_TYPE_VPS
          || param_array.NAL_unit_type == HEVC_NALU_TYPE_SPS


### PR DESCRIPTION
Without this, lsmash_destroy_codec_specific_data will segfault when it
tries to call a NULL eliminator. Seems like this spot was missed in
4b46719bfb7ef7bfad4f3b2ffd2cef8ae6e1128a back in 2017.