### PR TITLE
Include obuparse as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "obuparse"]
+	path = obuparse
+	url = https://github.com/dwbuiten/obuparse.git

--- a/codecs/av1_obu.c
+++ b/codecs/av1_obu.c
@@ -24,7 +24,7 @@
 
 #include <string.h>
 
-#include <obuparse.h>
+#include "obuparse/obuparse.h"
 
 #include "codecs/av1.h"
 #include "codecs/av1_obu.h"

--- a/configure
+++ b/configure
@@ -116,7 +116,7 @@ TOOLS=""
 CFLAGS="-Wshadow -Wall -std=c99 -pedantic -I. -I$SRCDIR"
 LDFLAGS="-L."
 SO_LDFLAGS='-shared -Wl,-soname,$@ -Wl,--version-script,liblsmash.ver'
-LIBS="-lm -lobuparse"
+LIBS="-lm"
 
 for opt; do
     optarg="${opt#*=}"
@@ -311,6 +311,9 @@ SRC_COMMON="   \
     osdep.c    \
     utils.c"
 
+SRC_OBUPARSE=" \
+    obuparse.c"
+
 SRC_CODECS="      \
     a52.c         \
     alac.c        \
@@ -363,6 +366,10 @@ SRCS=""
 
 for src in $SRC_COMMON; do
     SRCS="$SRCS common/$src"
+done
+
+for src in $SRC_OBUPARSE; do
+    SRCS="$SRCS obuparse/$src"
 done
 
 for src in $SRC_CODECS; do

--- a/importer/ivf_imp.c
+++ b/importer/ivf_imp.c
@@ -25,7 +25,7 @@
 
 #include <string.h>
 
-#include <obuparse.h>
+#include "obuparse/obuparse.h"
 
 #define LSMASH_IMPORTER_INTERNAL
 #include "importer.h"


### PR DESCRIPTION
obuparse doesn't have any external dependencies and can trivially be built alongside l-smash, it's also how it's recommended to be integrated with other programs in its readme. So rather than expecting it to be installed on the system, this adds it as a submodule and builds and links it with the rest of the code.