### PR TITLE
Add additional check for Audio Endian Box (https://github.com/HomeOfAviSynthPlusEvolution/L-SMASH-Works/issues/26)

### DIFF
--- a/codecs/description.c
+++ b/codecs/description.c
@@ -3164,7 +3164,7 @@ lsmash_summary_t *isom_create_audio_summary_from_description( isom_sample_entry_
                 }
             }
             isom_wave_t *wave = (isom_wave_t *)isom_get_extension_box_format( &audio->extensions, QT_BOX_TYPE_WAVE );
-            if( LSMASH_IS_EXISTING_BOX( wave->enda ) )
+            if( LSMASH_IS_EXISTING_BOX( wave->enda ) && wave->enda->size > 0 )
             {
                 if( wave->enda->littleEndian )
                     data->format_flags &= ~QT_LPCM_FORMAT_FLAG_BIG_ENDIAN;


### PR DESCRIPTION
It seems the Audio Endian Box is always initiliazed after d6f03e49661f4bb761eb749cafc257ccf1dd3c7e.