### PR TITLE
Allow spatial audio muxed via CLI to include head-locked stereo

### DIFF
--- a/cli/muxer.c
+++ b/cli/muxer.c
@@ -1188,7 +1188,8 @@ static int prepare_output( muxer_t *muxer )
                         if( track_opt->ambisonic_order < 0 )
                             return ERROR_MSG( "ambisonic order must be a positive integer\n" );
                         uint32_t ambisonic_channels = (track_opt->ambisonic_order + 1) * (track_opt->ambisonic_order + 1);
-                        if( ambisonic_channels != summary->channels )
+                        /* ensure that channel count matches ambisonic order, it can also have 2 extra channels if it includes head-locked stereo */
+                        if( ambisonic_channels != summary->channels && ambisonic_channels + 2 != summary->channels )
                             return ERROR_MSG( "ambisonic order's expected channel count does not match actual channel count\n" );
 
                         lsmash_codec_specific_t *SA3D = lsmash_create_codec_specific_data( LSMASH_CODEC_SPECIFIC_DATA_TYPE_ISOM_AUDIO_SA3D,


### PR DESCRIPTION
We error out when trying to set spatial audio metadata on a track that has the wrong number of channels. This also allows spatial audio injection to be performed on ambisonic tracks that include head-locked stereo channels at the end of the channel layout, adding 2 extra channels. In this case, the extra channels will be ignored during injection of spatial metadata.