### PR TITLE
Add CDM4 brand when muxing HEVC/AV1 ISO media files with HDR10+ dynamic metadata

### DIFF
--- a/cli/muxer.c
+++ b/cli/muxer.c
@@ -850,14 +850,42 @@ static int open_input_files( muxer_t *muxer )
                 if( !opt->isom && opt->qtff )
                     return ERROR_MSG( "the input seems AV1, at present available only for ISO Base Media file format.\n" );
                 if( opt->isom )
+                {
                     add_brand( opt, ISOM_BRAND_TYPE_AV01 );
+
+                    for( int i = 1; i <= lsmash_count_codec_specific_data( in_track->summary ); i++ )
+                    {
+                        lsmash_codec_specific_t *av1 = lsmash_get_codec_specific_data( in_track->summary, i );
+                        if ( !av1 )
+                            continue;
+                        if ( av1->type != LSMASH_CODEC_SPECIFIC_DATA_TYPE_ISOM_VIDEO_AV1 )
+                            continue;
+                        if ( ((lsmash_av1_specific_parameters_t *)av1->data.structured)->has_hdr10p )
+                            add_brand( opt, ISOM_BRAND_TYPE_CDM4 );
+                    }
+                }
             }
             else if( lsmash_check_codec_type_identical( codec_type, ISOM_CODEC_TYPE_HVC1_VIDEO ) )
             {
                 if( !opt->isom && opt->qtff )
                     return ERROR_MSG( "the input seems HEVC, at present available only for ISO Base Media file format.\n" );
-                if( in_track->opt.has_dv )
-                    add_brand( opt, ISOM_BRAND_TYPE_DBY1 );
+                if( opt->isom )
+                {
+                    if( in_track->opt.has_dv )
+                        add_brand( opt, ISOM_BRAND_TYPE_DBY1 );
+
+                    for( int i = 1; i <= lsmash_count_codec_specific_data( in_track->summary ); i++ )
+                    {
+                        lsmash_codec_specific_t *hevc = lsmash_get_codec_specific_data( in_track->summary, i );
+                        if ( !hevc )
+                            continue;
+                        if ( hevc->type != LSMASH_CODEC_SPECIFIC_DATA_TYPE_ISOM_VIDEO_HEVC )
+                            continue;
+                        if ( ((lsmash_hevc_specific_parameters_t *)hevc->data.structured)->has_hdr10p ) {
+                            add_brand( opt, ISOM_BRAND_TYPE_CDM4 );
+                        }
+                    }
+                }
             }
             else if( lsmash_check_codec_type_identical( codec_type, ISOM_CODEC_TYPE_VC_1_VIDEO ) )
             {

--- a/codecs/av1_obu.c
+++ b/codecs/av1_obu.c
@@ -171,10 +171,18 @@ lsmash_av1_specific_parameters_t *obu_av1_parse_first_tu
                     return NULL;
                 }
 
+                /*
+                 * Compare metadata OBU header bytes to expected HDR10+ dynamic metadata OBU header.
+                 * Offset by 2 due to start code and size bytes. The leading byte is an AV1-specific metadata type ID.
+                 */
+                if( obusize > 8 && memcmp( data + off + offset - pos + 2, "\x04\xb5\x00\x3c\x00\x01\x04\x01", 8 ) == 0 )
+                    param->has_hdr10p = 1;
+
                 uint32_t oldpos       = param->configOBUs.sz;
                 param->configOBUs.sz += obusize + pos;
                 uint8_t *newdata      = lsmash_realloc( param->configOBUs.data, param->configOBUs.sz );
-                if( !newdata ) {
+                if( !newdata )
+                {
                     av1_destruct_specific_data( param );
                     return NULL;
                 }

--- a/codecs/hevc.c
+++ b/codecs/hevc.c
@@ -1363,6 +1363,26 @@ int hevc_parse_sei
                 sei->mastering_display.max_display_mastering_luminance = lsmash_bits_get( bits, 32 );
                 sei->mastering_display.min_display_mastering_luminance = lsmash_bits_get( bits, 32 );
             }
+            else if( payloadType == HEVC_SEI_ITU_T_T35 )
+            {
+                /* Compare metadata header bytes to expected HDR10+ dynamic metadata header. */
+                if ( payloadSize > 8 )
+                {
+                    uint8_t country_code = lsmash_bits_get( bits, 8 );
+                    if ( country_code != 0xb5 )
+                        continue;
+                    uint16_t provider_code = lsmash_bits_get( bits, 16 );
+                    if ( provider_code != 0x003c )
+                        continue;
+                    uint16_t provider_oriented_code = lsmash_bits_get( bits, 16 );
+                    if ( provider_oriented_code != 0x0001 )
+                        continue;
+                    uint16_t application_identifier = lsmash_bits_get( bits, 16 );
+                    if ( application_identifier != 0x0401 )
+                        continue;
+                    sei->hdr10p_present = 1;
+                }
+            }
             else
                 goto skip_sei_message;
         }

--- a/codecs/hevc.h
+++ b/codecs/hevc.h
@@ -239,9 +239,10 @@ typedef struct
 
 typedef struct
 {
-    hevc_pic_timing_t     pic_timing;
-    hevc_recovery_point_t recovery_point;
+    hevc_pic_timing_t        pic_timing;
+    hevc_recovery_point_t    recovery_point;
     hevc_mastering_display_t mastering_display;
+    uint8_t                  hdr10p_present;
 } hevc_sei_t;
 
 /* Slice segment */

--- a/importer/nalu_imp.c
+++ b/importer/nalu_imp.c
@@ -1373,12 +1373,18 @@ static lsmash_video_summary_t *hevc_setup_first_summary
 )
 {
     hevc_importer_t *hevc_imp = (hevc_importer_t *)importer->info;
+    hevc_info_t *info = &hevc_imp->info;
     lsmash_codec_specific_t *cs = (lsmash_codec_specific_t *)lsmash_list_get_entry_data( hevc_imp->hvcC_list, ++ hevc_imp->hvcC_number );
     if( !cs || !cs->data.structured )
     {
         lsmash_destroy_codec_specific_data( cs );
         return NULL;
     }
+
+    lsmash_hevc_specific_parameters_t *hevc_cs = (lsmash_hevc_specific_parameters_t *)cs->data.structured;
+    if( info->sei.hdr10p_present )
+        hevc_cs->has_hdr10p = 1;
+
     lsmash_video_summary_t *summary = hevc_create_summary( (lsmash_hevc_specific_parameters_t *)cs->data.structured,
                                                            &hevc_imp->info.sps, hevc_imp->max_au_length );
     if( !summary )

--- a/lsmash.h
+++ b/lsmash.h
@@ -135,6 +135,7 @@ typedef enum
     ISOM_BRAND_TYPE_ARRI  = LSMASH_4CC( 'A', 'R', 'R', 'I' ),   /* ARRI Digital Camera */
     ISOM_BRAND_TYPE_CAEP  = LSMASH_4CC( 'C', 'A', 'E', 'P' ),   /* Canon Digital Camera */
     ISOM_BRAND_TYPE_CDES  = LSMASH_4CC( 'C', 'D', 'e', 's' ),   /* Convergent Designs */
+    ISOM_BRAND_TYPE_CDM4  = LSMASH_4CC( 'c', 'd', 'm', '4' ),   /* CMAF Media Profile with HDR10+ dynamic metadata */
     ISOM_BRAND_TYPE_LCAG  = LSMASH_4CC( 'L', 'C', 'A', 'G' ),   /* Leica digital camera */
     ISOM_BRAND_TYPE_M4A   = LSMASH_4CC( 'M', '4', 'A', ' ' ),   /* iTunes MPEG-4 audio protected or not */
     ISOM_BRAND_TYPE_M4B   = LSMASH_4CC( 'M', '4', 'B', ' ' ),   /* iTunes AudioBook protected or not */
@@ -3413,6 +3414,7 @@ typedef struct
                                                      *   NALUnitLength indicates the size of a NAL unit measured in bytes,
                                                      *   and includes the size of both the one byte NAL header and the EBSP payload
                                                      *   but does not include the length field itself. */
+    uint8_t  has_hdr10p;                            /* an ITU-T T.35 metadata SEI message was found with an HDR10+ dynamic metadata header. */
     /* a set of arrays to carry initialization NAL units
      * The NAL unit types are restricted to indicate VPS, SPS, PPS, and SEI NAL units only. */
     lsmash_hevc_parameter_arrays_t *parameter_arrays;
@@ -3463,6 +3465,7 @@ int lsmash_get_hevc_array_completeness
 /* Supported SEIs stored in hvcC */
 typedef enum
 {
+    HEVC_SEI_ITU_T_T35         = 4,
     HEVC_SEI_MASTERING_DISPLAY = 137,
 } lsmash_hevc_sei_payload_type;
 
@@ -3585,6 +3588,7 @@ typedef struct
                                                      * sample will be decoded prior to its presentation time under the constraints of the first level value
                                                      * indicated by seq_level_idx in the Sequence Header OBU (in the configOBUs field or in the associated
                                                      * samples). */
+    uint8_t has_hdr10p;                             /* an ITU-T T.35 metadata OBU was found with an HDR10+ dynamic metadata header. */
     lsmash_av1_config_obus_t configOBUs;            /* zero or more OBUs
                                                      * This field SHALL contain at most one Sequence Header OBU and if present, it SHALL be the first OBU.
                                                      * This field is expected to contain only one Sequence Header OBU and zero or more Metadata OBUs when


### PR DESCRIPTION
Presence of HDR10+ dynamic metadata is signaled through the `cdm4` brand. This adds an entry for it and adds automatic muxer support for HEVC and AV1 streams.

- While parsing a stream before muxing, check ITU-T T.35 user data SEI messages (HEVC) or metadata OBUs (AV1) and compare their headers to a known static signature matching HDR10+ dynamic metadata.

- When detected, set a flag in codec-specific information (`has_hdr10p`).

- After setting other codec-specific brands, add `cdm4` as well if `has_hdr10p` is non-zero positive.