### PR TITLE
Fix the prototype of lsmash_bits_adhoc_create

### DIFF
--- a/common/bits.c
+++ b/common/bits.c
@@ -171,7 +171,7 @@ int lsmash_bits_import_data( lsmash_bits_t *bits, void *data, uint32_t length )
  bitstream with bytestream for adhoc operation
 ****/
 
-lsmash_bits_t *lsmash_bits_adhoc_create()
+lsmash_bits_t *lsmash_bits_adhoc_create(void)
 {
     lsmash_bs_t *bs = lsmash_bs_create();
     if( !bs )

--- a/common/bits.h
+++ b/common/bits.h
@@ -38,5 +38,5 @@ uint64_t lsmash_bits_get( lsmash_bits_t *bits, uint32_t width );
 void *lsmash_bits_export_data( lsmash_bits_t *bits, uint32_t *length );
 int lsmash_bits_import_data( lsmash_bits_t *bits, void *data, uint32_t length );
 
-lsmash_bits_t *lsmash_bits_adhoc_create();
+lsmash_bits_t *lsmash_bits_adhoc_create(void);
 void lsmash_bits_adhoc_cleanup( lsmash_bits_t *bits );


### PR DESCRIPTION
This avoids warnings like this:

    common/bits.c:174:40: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
    lsmash_bits_t *lsmash_bits_adhoc_create()
                                           ^
                                            void