### PR TITLE
Identify and print the 'aid3' compatible_brand

### DIFF
--- a/core/print.c
+++ b/core/print.c
@@ -275,6 +275,7 @@ static void isom_print_brand_description( FILE *fp, lsmash_brand_type brand )
             { ISOM_BRAND_TYPE_MFSM, "Media File for Samsung video Metadata" },
             { ISOM_BRAND_TYPE_MPPI, "Photo Player Multimedia Application Format" },
             { ISOM_BRAND_TYPE_ROSS, "Ross Video" },
+            { ISOM_BRAND_TYPE_AID3, "AOM Timed ID3 Metadata" },
             { ISOM_BRAND_TYPE_AVC1, "Advanced Video Coding extensions" },
             { ISOM_BRAND_TYPE_BBXM, "Blinkbox Master File" },
             { ISOM_BRAND_TYPE_CAQV, "Casio Digital Camera" },

--- a/lsmash.h
+++ b/lsmash.h
@@ -145,6 +145,7 @@ typedef enum
     ISOM_BRAND_TYPE_MPPI  = LSMASH_4CC( 'M', 'P', 'P', 'I' ),   /* Photo Player Multimedia Application Format */
     ISOM_BRAND_TYPE_OPUS  = LSMASH_4CC( 'O', 'p', 'u', 's' ),   /* Opus */
     ISOM_BRAND_TYPE_ROSS  = LSMASH_4CC( 'R', 'O', 'S', 'S' ),   /* Ross Video */
+    ISOM_BRAND_TYPE_AID3  = LSMASH_4CC( 'a', 'i', 'd', '3' ),   /* AOM Timed ID3 Metadata */
     ISOM_BRAND_TYPE_AV01  = LSMASH_4CC( 'a', 'v', '0', '1' ),   /* AV1 */
     ISOM_BRAND_TYPE_AVC1  = LSMASH_4CC( 'a', 'v', 'c', '1' ),   /* Advanced Video Coding extensions */
     ISOM_BRAND_TYPE_BBXM  = LSMASH_4CC( 'b', 'b', 'x', 'm' ),   /* Blinkbox Master File */


### PR DESCRIPTION
This is specified at https://aomediacodec.github.io/id3-emsg/.