### PR TITLE
configure: Fix compilation on macOS

### DIFF
--- a/configure
+++ b/configure
@@ -218,19 +218,19 @@ case "$TARGET_OS" in
             if is_64bit ; then
                 LIBARCH=x64
             fi
-            SLIB_CMD='sed -i "s/ @[^ ]*//" $(DEFNAME); lib.exe -machine:$(LIBARCH) -def:$(DEFNAME) -out:lsmash.lib'
+            SLIB_CMD='sed -i.orig "s/ @[^ ]*//" $(DEFNAME); rm -f $(DEFNAME).orig; lib.exe -machine:$(LIBARCH) -def:$(DEFNAME) -out:lsmash.lib'
         elif genlib -V > /dev/null 2>&1 ; then
             if is_64bit ; then
                 LIBARCH=x86_64
             else
                 LIBARCH=x86
             fi
-            SLIB_CMD='sed -i "s/ @[^ ]*//" $(DEFNAME); genlib -a $(LIBARCH) -o lsmash.lib -d $(SHAREDLIBNAME) $(DEFNAME)'
+            SLIB_CMD='sed -i.orig "s/ @[^ ]*//" $(DEFNAME); rm -f $(DEFNAME).orig; genlib -a $(LIBARCH) -o lsmash.lib -d $(SHAREDLIBNAME) $(DEFNAME)'
         elif ${CROSS}dlltool --version > /dev/null 2>&1 ; then
             if is_64bit ; then
                 LIBARCH="i386:x86-64"
             fi
-            SLIB_CMD="sed -i \"s/ @[^ ]*//\" \$(DEFNAME); ${CROSS}dlltool -m \$(LIBARCH) -d \$(DEFNAME) -l lsmash.lib -D \$(SHAREDLIBNAME)"
+            SLIB_CMD="sed -i.orig \"s/ @[^ ]*//\" \$(DEFNAME); rm -f \$(DEFNAME).orig; ${CROSS}dlltool -m \$(LIBARCH) -d \$(DEFNAME) -l lsmash.lib -D \$(SHAREDLIBNAME)"
         fi
         ;;
     *cygwin*)
@@ -426,9 +426,11 @@ sed "s/\\\$MAJOR/$MAJVER/" $SRCDIR/liblsmash.v > liblsmash.ver
 # Add non-public symbols which have lsmash_* prefix to local.
 find $SRCDIR/common/ $SRCDIR/importer/ -name "*.h" | xargs sed -e 's/^[ ]*//g' | \
     grep "^\(void\|lsmash_bits_t\|uint64_t\|int\|int64_t\|lsmash_bs_t\|uint8_t\|uint16_t\|uint32_t\|lsmash_entry_list_t\|lsmash_entry_t\|lsmash_multiple_buffers_t\|double\|float\|FILE\) \+\*\{0,1\}lsmash_" | \
-    sed -e "s/.*\(lsmash_.*\)(.*/\1/g" -e "s/.*\(lsmash_.*\)/\1;/g" | xargs -I% sed -i "/^};$/i \           %" liblsmash.ver
+    sed -e 's/.*\(lsmash_.*\)(.*/\1/g' -e 's/.*\(lsmash_.*\)/\1;/g' | \
+    xargs -I% sed -i.orig '/^};$/i\
+            %' liblsmash.ver
 # Get rid of non-public symbols for the cli tools from local.
-sed -i -e '/lsmash_win32_fopen/d' \
+sed -i.orig -e '/lsmash_win32_fopen/d' \
     -e '/lsmash_string_from_wchar/d' \
     -e '/lsmash_importer_open/d' \
     -e '/lsmash_importer_close/d' \
@@ -437,6 +439,9 @@ sed -i -e '/lsmash_win32_fopen/d' \
     -e '/lsmash_importer_construct_timeline/d' \
     -e '/lsmash_importer_get_track_count/d' \
     -e '/lsmash_duplicate_summary/d' liblsmash.ver
+cat liblsmash.ver
+# Remove backup file
+rm -f liblsmash.ver.orig
 
 
 cat >> liblsmash.pc << EOF


### PR DESCRIPTION
On macOS `sed -i` require extension to be specified.